### PR TITLE
Small fix in CopyToResultDir

### DIFF
--- a/compute4/NGS_alignment_SNP_calling/protocols/CopyToResultsDir.ftl
+++ b/compute4/NGS_alignment_SNP_calling/protocols/CopyToResultsDir.ftl
@@ -126,6 +126,7 @@ cd ${projectResultsDir}
 zip -r ${projectResultsDir}/${project}.zip snps
 zip -gr ${projectResultsDir}/${project}.zip qc
 zip -gr ${projectResultsDir}/${project}.zip structural_variants
+zip -gr ${projectResultsDir}/${project}.zip coverage_visualization
 zip -g ${projectResultsDir}/${project}.zip ${project}.csv
 zip -g ${projectResultsDir}/${project}.zip README.pdf
 zip -g ${projectResultsDir}/${project}.zip ${project}_QCReport.pdf


### PR DESCRIPTION
Generated coverage bed.gz files were not added to final project gzip deliverable.
