### PR TITLE
fixed paste tab problem

### DIFF
--- a/compute5/Imputation_impute2/protocols/concatImpute2ChrResults_samples.sh
+++ b/compute5/Imputation_impute2/protocols/concatImpute2ChrResults_samples.sh
@@ -59,9 +59,9 @@ rm -f ${imputationIntermediatesFolder}/~chr${chr}_${fromChrPos}-${toChrPos}_info
 rm -f ${imputationIntermediatesFolder}/chr${chr}_${fromChrPos}-${toChrPos}_info
 
 #Merging chunks
-toExecute="paste <(cut -d ' ' -f 1-5 ${imputation__has__impute2ChunkOutput[0]})"
+toExecute="paste -d ' ' <(cut -d ' ' -f 1-5 ${imputation__has__impute2ChunkOutput[0]})"
 concatCommandColumns="cut -d ' ' -f 1-5 ${imputation__has__impute2ChunkOutput[0]} > ${imputationIntermediatesFolder}/~chr${chr}_${fromChrPos}-${toChrPos}.columns"
-concatCommand="paste ${imputationIntermediatesFolder}/~chr${chr}_${fromChrPos}-${toChrPos}.columns "
+concatCommand="paste -d ' ' ${imputationIntermediatesFolder}/~chr${chr}_${fromChrPos}-${toChrPos}.columns "
 echo "Running: ${concatCommandColumns}"
 eval ${concatCommandColumns}
 indexVar=0


### PR DESCRIPTION
Copying from Patrick/Freerk mail:
Hi Freerk and Alex,

There is a small bug in the imputation script. Gen files can only contain spaces but contain a tab after the alleles

--- 1-10478 10478 C G                   1 0 0
Alex:
This is indeed a serious bug:
http://www.stats.ox.ac.uk/~marchini/software/gwas/file_format.html#Genotype_File_Format
although it does not make clear what is the proper delimiter for .gen files, it does make it clear for .sample files:
Use spaces to separate the entries of the sample file and not TABS.

Fix: I added the -d ' ' parameter in paste command
