### PR TITLE
Remove fastq files after CRAMing

### DIFF
--- a/compute5/Public_RNA-seq_QC/protocols/AddOrReplaceReadGroups.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/AddOrReplaceReadGroups.sh
@@ -25,7 +25,7 @@ echo "## "$(date)" Start $0"
 
 tmpBam=$TMPDIR/$(basename ${sortedBam})
 
-java -Xmx6g -XX:ParallelGCThreads=8 -jar $EBROOTPICARD/AddOrReplaceReadGroups.jar \
+java -Xmx6g -XX:ParallelGCThreads=8 -jar $EBROOTPICARD/picard.jar AddOrReplaceReadGroups \
  INPUT=${sortedBam} \
  OUTPUT=$tmpBam \
  SORT_ORDER=coordinate \

--- a/compute5/Public_RNA-seq_QC/protocols/CollectMultipleMetrics.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/CollectMultipleMetrics.sh
@@ -37,7 +37,7 @@ fi
 
 #Run Picard CollectAlignmentSummaryMetrics, CollectInsertSizeMetrics, QualityScoreDistribution and MeanQualityByCycle
 
-echo java -jar -Xmx4g -XX:ParallelGCThreads=4 $EBROOTPICARD/CollectMultipleMetrics.jar \
+echo java -jar -Xmx4g -XX:ParallelGCThreads=4 $EBROOTPICARD/picard.jar CollectMultipleMetrics \
         I=${sortedBam} \
         O=${collectMultipleMetricsPrefix} \
         R=${onekgGenomeFasta} \
@@ -47,7 +47,7 @@ echo java -jar -Xmx4g -XX:ParallelGCThreads=4 $EBROOTPICARD/CollectMultipleMetri
         $insertSizeMetrics \
         TMP_DIR=${collectMultipleMetricsDir}
         
-java -jar -Xmx4g -XX:ParallelGCThreads=4 $EBROOTPICARD/CollectMultipleMetrics.jar \
+java -jar -Xmx4g -XX:ParallelGCThreads=4 $EBROOTPICARD/picard.jar CollectMultipleMetrics \
  I=${sortedBam} \
  O=${collectMultipleMetricsPrefix} \
  R=${onekgGenomeFasta} \

--- a/compute5/Public_RNA-seq_QC/protocols/CollectRnaSeqMetrics.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/CollectRnaSeqMetrics.sh
@@ -32,7 +32,7 @@ mkdir -p ${collectRnaSeqMetricsDir}
 echo "## "$(date)" Start $0"
 echo "ID (internalId-project-sampleName): ${internalId}-${project}-${sampleName}"
 
-java -Xmx8g -XX:ParallelGCThreads=4 -jar $EBROOTPICARD/CollectRnaSeqMetrics.jar \
+java -Xmx8g -XX:ParallelGCThreads=4 -jar $EBROOTPICARD/picard.jar CollectRnaSeqMetrics \
  INPUT=${sortedBam} \
  OUTPUT=${collectRnaSeqMetrics} \
  CHART_OUTPUT=${collectRnaSeqMetricsChart} \

--- a/compute5/Public_RNA-seq_QC/protocols/CreateCramFiles.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/CreateCramFiles.sh
@@ -33,7 +33,7 @@ echo "ID (internalId-project-sampleName): ${internalId}-${project}-${sampleName}
 
 #Use old picard instead of new one "picard.jar FixMateInformation"
 java -Xmx8g -XX:ParallelGCThreads=2 -Djava.io.tmpdir=${tmpCramFileDir} \
- -jar $EBROOTPICARD/FixMateInformation.jar \
+ -jar $EBROOTPICARD/picard.jar FixMateInformation \
  INPUT=${unfilteredBamDir}/${uniqueID}.bam \
  OUTPUT=${tmpCramFileDir}${uniqueID}.fixmates.bam \
  VALIDATION_STRINGENCY=LENIENT \

--- a/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
@@ -100,7 +100,7 @@ else
   fastq2Lines=$(cat $TMPDIR/$fq2Name | wc -l)
   echo "fastq1Lines: $fastq1Lines"
   echo "fastq2Lines: $fastq2Lines"
-  originalFastq2lines=$(zcat ${reads2FqGz} | wc -l)
+  originalFastq2Lines=$(zcat ${reads2FqGz} | wc -l)
 fi
 
 returnCode=$?
@@ -126,7 +126,7 @@ then
   then
     :
   else
-      echo "originalFastq2lines: $originalFastq2lines"
+      echo "originalFastq2Lines: $originalFastq2Lines"
     if [ "$originalFastq2Lines" -eq "$fastq2Lines" ];
     then
       echo "Fastq2 same number of lines"

--- a/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
@@ -85,7 +85,7 @@ then
       -0 $TMPDIR/$fq1Name \
       $TMPDIR/${uniqueID}.sorted.bam
     echo "count fastq lines"
-    fastq1Lines=$(wc -l $TMPDIR/$fq1Name)
+    fastq1Lines=$(cat $TMPDIR/$fq1Name | wc -l)
     echo "fastq1Lines: $fastq1Lines"
 else
   samtools fastq \
@@ -95,8 +95,8 @@ else
       $TMPDIR/${uniqueID}.sorted.bam
 
   echo "count fastq lines"
-  fastq1Lines=$(wc -l $TMPDIR/$fq1Name)
-  fastq2Lines=$(wc -l $TMPDIR/$fq2Name)
+  fastq1Lines=$(cat $TMPDIR/$fq1Name | wc -l)
+  fastq2Lines=$(cat $TMPDIR/$fq2Name | wc -l)
   echo "fastq1Lines: $fastq1Lines"
   echo "fastq2Lines: $fastq2Lines"
   originalFastq2lines=$(zcat ${reads2FqGz} | wc -l)
@@ -117,7 +117,7 @@ echo "count original fastq lines"
 originalFastq1Lines=$(zcat ${reads1FqGz} | wc -l)
 
 
-    echo "originalFastq1Lines: $originalFastq1Lines"
+echo "originalFastq1Lines: $originalFastq1Lines"
 if [ "$originalFastq1Lines" -eq "$fastq1Lines" ];
 then
   echo "Fastq1 same number of lines"

--- a/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
@@ -54,18 +54,12 @@ else
   exit 1;
 fi
 
-#echo "Starting BAM to FASTQ conversion: sort BAM file";
-#samtools sort \
-#    -@ 4 \
-#    -n \
-#    -o $TMPDIR/${uniqueID}.sorted.bam \
-#    $TMPDIR/${uniqueID}.bam
-
-echo "Starting BAM to FASTQ conversion: make unaligned BAM file";
-java -Xmx8G -jar -XX:ParallelGCThreads=4 ${EBROOTPICARD}/picard.jar RevertSam \
-    I=$TMPDIR/${uniqueID}.bam \
-    O=$TMPDIR/${uniqueID}.revertSam.bam \
-    VALIDATION_STRINGENCY=LENIENT
+echo "Starting BAM to FASTQ conversion: sort BAM file";
+samtools sort \
+    -@ 4 \
+    -n \
+    -o $TMPDIR/${uniqueID}.sorted.bam \
+    $TMPDIR/${uniqueID}.bam
 
 returnCode=$?
 echo "returncode: $returnCode";
@@ -83,14 +77,13 @@ fq1Name=${fq1NameGz%.gz}
 fq2NameGz=$(basename $reads2FqGz)
 fq2Name=${fq2NameGz%.gz}
 
-echo "Starting BAM to FASTQ conversion: convert unaligned BAM file to fastq"
+echo "Starting BAM to FASTQ conversion: convert sorted BAM file to fastq"
 if [ ${#reads2FqGz} -eq 0 ];
 then
   samtools fastq \
       -@ 4 \
       -0 $TMPDIR/$fq1Name \
-      $TMPDIR/${uniqueID}.revertSam.bam
-#      $TMPDIR/${uniqueID}.sorted.bam
+      $TMPDIR/${uniqueID}.sorted.bam
     echo "count fastq lines"
     fastq1Lines=$(cat $TMPDIR/$fq1Name | wc -l)
     echo "fastq1Lines: $fastq1Lines"
@@ -99,8 +92,7 @@ else
       -@ 4 \
       -1 $TMPDIR/$fq1Name \
       -2 $TMPDIR/$fq2Name \
-      $TMPDIR/${uniqueID}.revertSam.bam
-#      $TMPDIR/${uniqueID}.sorted.bam
+      $TMPDIR/${uniqueID}.sorted.bam
 
   echo "count fastq lines"
   fastq1Lines=$(cat $TMPDIR/$fq1Name | wc -l)

--- a/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
@@ -130,7 +130,7 @@ then
     if [ "$originalFastq2Lines" -eq "$fastq2Lines" ];
     then
       echo "Fastq2 same number of lines"
-      echo rm $reads2FqGz
+      rm $reads2FqGz
     else
       echo "ERROR: Fastq2 not same number of lines"
       exit 1;

--- a/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
@@ -1,4 +1,4 @@
-#MOLGENIS nodes=1 ppn=4 mem=8gb walltime=08:00:00
+#MOLGENIS nodes=1 ppn=4 mem=12gb walltime=08:00:00
 
 ### variables to help adding to database (have to use weave)
 #string internalId

--- a/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
@@ -60,6 +60,7 @@ samtools sort \
     -n \
     -o $TMPDIR/${uniqueID}.sorted.bam \
     $TMPDIR/${uniqueID}.bam
+rm $TMPDIR/${uniqueID}.bam
 
 returnCode=$?
 echo "returncode: $returnCode";

--- a/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
@@ -61,23 +61,11 @@ fi
 #    -o $TMPDIR/${uniqueID}.sorted.bam \
 #    $TMPDIR/${uniqueID}.bam
 
-
-# from https://gatkforums.broadinstitute.org/firecloud/discussion/6484
 echo "Starting BAM to FASTQ conversion: make unaligned BAM file";
 java -Xmx8G -jar -XX:ParallelGCThreads=4 ${EBROOTPICARD}/picard.jar RevertSam \
     I=$TMPDIR/${uniqueID}.bam \
     O=$TMPDIR/${uniqueID}.revertSam.bam \
-    SANITIZE=true \
-    MAX_DISCARD_FRACTION=0.005 \ #informational; does not affect processing
-    ATTRIBUTE_TO_CLEAR=XT \
-    ATTRIBUTE_TO_CLEAR=XN \
-    ATTRIBUTE_TO_CLEAR=AS \ #Picard release of 9/2015 clears AS by default
-    ATTRIBUTE_TO_CLEAR=OC \
-    ATTRIBUTE_TO_CLEAR=OP \
-    SORT_ORDER=queryname \ #default
-    RESTORE_ORIGINAL_QUALITIES=true \ #default
-    REMOVE_DUPLICATE_INFORMATION=true \ #default
-    REMOVE_ALIGNMENT_INFORMATION=true #default
+    VALIDATION_STRINGENCY=LENIENT
 
 returnCode=$?
 echo "returncode: $returnCode";

--- a/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
@@ -130,12 +130,14 @@ then
     if [ "$originalFastq2Lines" -eq "$fastq2Lines" ];
     then
       echo "Fastq2 same number of lines"
+      echo "Deleting $reads2FqGz...."
       rm $reads2FqGz
     else
       echo "ERROR: Fastq2 not same number of lines"
       exit 1;
     fi
   fi
+  echo "Deleting $reads1FqGz...."
   rm $reads1FqGz
 else
   echo "ERROR: Fastq1 not same number of lines"

--- a/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/RemoveFastqFiles.sh
@@ -130,13 +130,13 @@ then
     if [ "$originalFastq2Lines" -eq "$fastq2Lines" ];
     then
       echo "Fastq2 same number of lines"
-      echo "rm $reads2FqGz"
+      echo rm $reads2FqGz
     else
       echo "ERROR: Fastq2 not same number of lines"
       exit 1;
     fi
   fi
-  echo "rm $reads1FqGz"
+  rm $reads1FqGz
 else
   echo "ERROR: Fastq1 not same number of lines"
   exit 1;

--- a/compute5/Public_RNA-seq_QC/protocols/STARMapping.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/STARMapping.sh
@@ -64,7 +64,8 @@ then
 		--outFilterMultimapNmax 1 \
 		--outFilterMismatchNmax ${numMism} \
 		--twopassMode ${twoPassMethod} \
-        --quantMode GeneCounts
+        --quantMode GeneCounts \
+        --outSamUnmapped Within
 	starReturnCode=$?
 
 elif [ ${seqType} == "PE" ]
@@ -82,7 +83,8 @@ then
 		--outFilterMultimapNmax 1 \
 		--outFilterMismatchNmax ${numMism} \
 		--twopassMode ${twoPassMethod} \
-        --quantMode GeneCounts
+        --quantMode GeneCounts \
+        --outSamUnmapped Within
 	starReturnCode=$?
 else
 	echo "Seqtype unknown"

--- a/compute5/Public_RNA-seq_QC/protocols/STARMapping.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/STARMapping.sh
@@ -1,4 +1,4 @@
-#MOLGENIS walltime=24:00:00 nodes=1 ppn=14 mem=40gb
+#MOLGENIS walltime=24:00:00 nodes=1 ppn=8 mem=40gb
 
 #Parameter mapping
 #string reads1FqGz

--- a/compute5/Public_RNA-seq_QC/protocols/STARMapping.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/STARMapping.sh
@@ -65,7 +65,7 @@ then
 		--outFilterMismatchNmax ${numMism} \
 		--twopassMode ${twoPassMethod} \
         --quantMode GeneCounts \
-        --outSamUnmapped Within
+        --outSAMunmapped Within
 	starReturnCode=$?
 
 elif [ ${seqType} == "PE" ]
@@ -84,7 +84,7 @@ then
 		--outFilterMismatchNmax ${numMism} \
 		--twopassMode ${twoPassMethod} \
         --quantMode GeneCounts \
-        --outSamUnmapped Within
+        --outSAMunmapped Within
 	starReturnCode=$?
 else
 	echo "Seqtype unknown"

--- a/compute5/Public_RNA-seq_QC/protocols/SortBam.sh
+++ b/compute5/Public_RNA-seq_QC/protocols/SortBam.sh
@@ -30,7 +30,7 @@ mkdir -p ${sortedBamDir}
 echo "## "$(date)" Start $0"
 echo "ID (internalId-project-sampleName): ${internalId}-${project}-${sampleName}"
 
-java -Xmx6g -XX:ParallelGCThreads=4 -jar $EBROOTPICARD/SortSam.jar \
+java -Xmx6g -XX:ParallelGCThreads=4 -jar $EBROOTPICARD/picard.jar SortSam \
   INPUT=${filteredBam} \
   OUTPUT=${sortedBam} \
   SO=coordinate \


### PR DESCRIPTION
- Updated protocols using picard to newer picard version (picard.jar <too> instead of picard<tool>.jar
- Changed STAR to output unmapped reads in output so that CRAM contains all reads that fastq file contained